### PR TITLE
Remove .#apps output

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -83,15 +83,6 @@ in
       in
       {
         inherit packages;
-        apps = pkgs.lib.mapAttrs'
-          (name: _: {
-            inherit name;
-            value = {
-              type = "app";
-              program = packages.${name};
-            };
-          })
-          config.process-compose.configs;
       };
   };
 }


### PR DESCRIPTION
This is redundant because `nix run` will automatically run the `package` if the corresponding `app` is missing.

More importantly, with this change, the user has control over their actual app; they can, for example, wrap the `package` and do some pre-processing before actually starting process-compose through writing a custom flake app under the same name; see https://github.com/nammayatri/nammayatri/pull/452 for instance.