### PR TITLE
Add a default value for top-level option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -17,6 +17,7 @@ in
             process-compose-flake: creates [process-compose](https://github.com/F1bonacc1/process-compose)
             executables from process-compose configurations written as Nix attribute sets.
           '';
+          default = { };
           type = types.submodule {
             options = {
               package = mkOption {


### PR DESCRIPTION
Without this, importing the module but never using it breaks the flake.