### PR TITLE
Allow per-config tui/port options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Let's say you want to have a `devShell` that makes a command `watch-server` avai
 
 To achieve this using `process-compose-flake` you can simply add the following code to the `perSystem` function in your `flake-parts` flake.
 ```nix
-process-compose.configs = {
-  watch-server.processes = {
+process-compose.watch-server = {
+  settings.processes = {
     backend-server.command = "${self'.apps.backend-server.program} --port 9000";
     frontend-server.command = "${self'.apps.frontend-server.program} --port 9001";
     proxy-server.command =

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -16,9 +16,9 @@
         inputs.process-compose-flake.flakeModule
       ];
       perSystem = { pkgs, lib, ... }: {
-        process-compose = {
-          # This adds a `self.packages.default`
-          configs."default" = {
+        # This adds a `self.packages.default`
+        process-compose."default" = {
+          settings = {
             processes = {
 
               # Print a pony every 2 seconds, because why not.

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -13,10 +13,10 @@
         inputs.process-compose-flake.flakeModule
       ];
       perSystem = { pkgs, lib, ... }: {
-        process-compose = {
+        # This adds a `self.packages.default`
+        process-compose."default" = {
           tui = false;
-          # This adds a `self.packages.default`
-          configs."default" = {
+          settings = {
             processes = {
 
               # Create a simple sqlite db


### PR DESCRIPTION
To do this, we must restructure the options such as that the top-level option is an attrset of submodules. Each submodule then can have its own port/tui (cli) options.