### PR TITLE
Refactor: split into modules

### DIFF
--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -9,108 +9,83 @@ let
     literalExpression;
 in
 {
-  options = {
-    perSystem = mkPerSystemOption
-      ({ config, self', inputs', pkgs, system, ... }: {
-        options.process-compose = mkOption {
-          description = mdDoc ''
-            process-compose-flake: creates [process-compose](https://github.com/F1bonacc1/process-compose)
-            executables from process-compose configurations written as Nix attribute sets.
-          '';
-          type = types.attrsOf (types.submodule ({ config, ... }: {
-            options = {
-              package = mkOption {
-                type = types.package;
-                default = pkgs.process-compose;
-                defaultText = lib.literalExpression "pkgs.process-compose";
-                description = ''
-                  The process-compose package to bundle up in the command package and flake app.
-                '';
-              };
-              settings = mkOption {
-                type = (pkgs.formats.yaml { }).type;
-                example =
-                  # packages.${system}.watch-server becomes available
-                  # execute `nix run .#watch-server` or incude packages.${system}.watch-server
-                  # as a nativeBuildInput to your devShell
-                  literalExpression ''
-                    {
-                      watch-server = {
-                        processes = {
-                          backend = "''${pkgs.simple-http-server}";
-                          frontend = "''${pkgs.simple-http-server}";
-                        };
-                      };
-                    };
-                  '';
-                description = mdDoc ''
-                  For each attribute `x = process-compose config` a flake app and package `x` is added to the flake.
-                  Which runs process-compose with the declared config.
-                '';
-              };
-              port = mkOption {
-                type = types.nullOr types.int;
-                default = null;
-                description = ''
-                  Port to serve process-compose's Swagger API on.
-                '';
-              };
-              tui = mkOption {
-                type = types.nullOr types.bool;
-                default = null;
-                description = "Enable or disable the TUI for the application.";
-              };
-              extraCliArgs =
-                let
-                  cliArgsAttr = {
-                    port = "-p ${toString config.port}";
-                    tui = "-t=${lib.boolToString config.tui}";
-                  };
-                  getCliArgs =
-                    lib.mapAttrsToList
-                      (opt: arg: lib.optionalString (config.${opt} != null) arg)
-                      cliArgsAttr;
-                in
-                mkOption {
-                  type = types.str;
-                  default = lib.concatStringsSep " " getCliArgs;
-                  internal = true;
-                  readOnly = true;
-                  description = ''
-                    Extra command-line arguments to pass to process-compose.
-                  '';
-                };
-            };
-          }));
+  options.perSystem = mkPerSystemOption ({ config, pkgs, lib, ... }:
+    let
+      submoduleWithPkgs = mod:
+        types.submoduleWith {
+          specialArgs = { inherit pkgs lib; };
+          modules = [ mod ];
         };
-      });
-  };
-  config = {
-    perSystem = { config, self', inputs', pkgs, ... }:
-      let
-        toYAMLFile =
-          attrs:
-          pkgs.runCommand "toYamlFile" { buildInputs = [ pkgs.yq-go ]; } ''
-            yq -P '.' ${pkgs.writeTextFile { name = "tmp.json"; text = (builtins.toJSON attrs); }} > $out
-          '';
-        packages = pkgs.lib.mapAttrs
-          (name: cfg:
-            pkgs.writeShellApplication {
-              inherit name;
-              runtimeInputs = [ cfg.package ];
-              text = ''
-                process-compose up \
-                  -f ${toYAMLFile cfg.settings} \
-                  ${cfg.extraCliArgs} \
-                  "$@"
+    in
+    {
+      options.process-compose = mkOption {
+        description = mdDoc ''
+          process-compose-flake: creates [process-compose](https://github.com/F1bonacc1/process-compose)
+          executables from process-compose configurations written as Nix attribute sets.
+        '';
+        type = types.attrsOf (submoduleWithPkgs ({ config, ... }: {
+          imports = [
+            ./settings.nix
+          ];
+          options = {
+            package = mkOption {
+              type = types.package;
+              default = pkgs.process-compose;
+              defaultText = lib.literalExpression "pkgs.process-compose";
+              description = ''
+                The process-compose package to bundle up in the command package and flake app.
               '';
-            }
-          )
-          config.process-compose;
-      in
-      {
-        inherit packages;
+            };
+            port = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                Port to serve process-compose's Swagger API on.
+              '';
+            };
+            tui = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "Enable or disable the TUI for the application.";
+            };
+            extraCliArgs =
+              let
+                cliArgsAttr = {
+                  port = "-p ${toString config.port}";
+                  tui = "-t=${lib.boolToString config.tui}";
+                };
+                getCliArgs =
+                  lib.mapAttrsToList
+                    (opt: arg: lib.optionalString (config.${opt} != null) arg)
+                    cliArgsAttr;
+              in
+              mkOption {
+                type = types.str;
+                default = lib.concatStringsSep " " getCliArgs;
+                internal = true;
+                readOnly = true;
+                description = ''
+                  Extra command-line arguments to pass to process-compose.
+                '';
+              };
+          };
+        }));
       };
-  };
+
+      config.packages = lib.mapAttrs
+        (name: cfg:
+          pkgs.writeShellApplication {
+            inherit name;
+            runtimeInputs = [ cfg.package ];
+            text = ''
+              process-compose up \
+                -f ${cfg.settingsYaml} \
+                ${cfg.extraCliArgs} \
+                "$@"
+            '';
+          }
+        )
+        config.process-compose;
+    });
 }
 

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -1,0 +1,72 @@
+{ name, config, pkgs, lib, ... }: 
+
+let 
+  inherit (lib) types mkOption literalExpression;
+in 
+{
+  imports = [
+    ./settings.nix
+  ];
+
+  options = {
+    package = mkOption {
+      type = types.package;
+      default = pkgs.process-compose;
+      defaultText = lib.literalExpression "pkgs.process-compose";
+      description = ''
+        The process-compose package to bundle up in the command package and flake app.
+      '';
+    };
+    port = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Port to serve process-compose's Swagger API on.
+      '';
+    };
+    tui = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = "Enable or disable the TUI for the application.";
+    };
+    extraCliArgs =
+      let
+        cliArgsAttr = {
+          port = "-p ${toString config.port}";
+          tui = "-t=${lib.boolToString config.tui}";
+        };
+        getCliArgs =
+          lib.mapAttrsToList
+            (opt: arg: lib.optionalString (config.${opt} != null) arg)
+            cliArgsAttr;
+      in
+      mkOption {
+        type = types.str;
+        default = lib.concatStringsSep " " getCliArgs;
+        internal = true;
+        readOnly = true;
+        description = ''
+          Extra command-line arguments to pass to process-compose.
+        '';
+      };
+    outputs.package = mkOption {
+      type = types.package;
+      description = ''
+        The final package that will run 'process-compose up' for this configuration.
+      '';
+    };
+  };
+
+  config.outputs.package =
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = [ config.package ];
+      text = ''
+        process-compose up \
+          -f ${config.settingsYaml} \
+          ${config.extraCliArgs} \
+          "$@"
+      '';
+    };
+}
+

--- a/nix/process-compose/settings.nix
+++ b/nix/process-compose/settings.nix
@@ -1,7 +1,8 @@
 { name, config, pkgs, lib, ... }: 
 let 
   inherit (lib) types mkOption literalExpression;
-in {
+in 
+{
   options = {
     settings = mkOption {
       type = (pkgs.formats.yaml { }).type;

--- a/nix/settings.nix
+++ b/nix/settings.nix
@@ -1,0 +1,43 @@
+{ name, config, pkgs, lib, ... }: 
+let 
+  inherit (lib) types mkOption literalExpression;
+in {
+  options = {
+    settings = mkOption {
+      type = (pkgs.formats.yaml { }).type;
+      example =
+        # packages.${system}.watch-server becomes available
+        # execute `nix run .#watch-server` or incude packages.${system}.watch-server
+        # as a nativeBuildInput to your devShell
+        literalExpression ''
+          {
+            watch-server = {
+              processes = {
+                backend = "''${pkgs.simple-http-server}";
+                frontend = "''${pkgs.simple-http-server}";
+              };
+            };
+          };
+        '';
+      description = ''
+        For each attribute `x = process-compose config` a flake app and package `x` is added to the flake.
+        Which runs process-compose with the declared config.
+      '';
+    };
+
+    settingsYaml = mkOption {
+      type = types.attrsOf types.raw;
+      internal = true;
+    };
+  };
+  config.settingsYaml =
+    let
+      toYAMLFile =
+        attrs:
+        pkgs.runCommand "toYamlFile" { buildInputs = [ pkgs.yq-go ]; } ''
+          yq -P '.' ${pkgs.writeTextFile { name = "process-compose-${name}.json"; text = (builtins.toJSON attrs); }} > $out
+        '';
+    in
+    toYAMLFile config.settings;
+}
+


### PR DESCRIPTION
In preparation for doing #2 

Also,

- Add `outputs.package` option exporting the final package