### PR TITLE
Fix definiton of probe.exec

### DIFF
--- a/nix/process-compose/settings/probe.nix
+++ b/nix/process-compose/settings/probe.nix
@@ -37,7 +37,7 @@ in
     };
     exec = mkOption {
       type = types.nullOr (types.submodule {
-        command = mkOption {
+        options.command = mkOption {
           type = types.str;
           example = "ps -ef | grep -v grep | grep my-proccess";
         };


### PR DESCRIPTION
types.submodule defaults to assuming the contents are a config. When using liveness_probe.exec.command you get an error due to the exec submodule not being defined correctly.