### PR TITLE
improve process-compose wrapper to allow calling sub-commands other than up

### DIFF
--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -6,40 +6,17 @@ in
 {
   options = {
     port = mkOption {
-      type = types.nullOr types.int;
-      default = null;
+      type = types.int;
+      default = 8080;
       description = ''
         Port to serve process-compose's Swagger API on.
       '';
     };
     tui = mkOption {
-      type = types.nullOr types.bool;
-      default = null;
+      type = types.bool;
+      default = true;
       description = "Enable or disable the TUI for the application.";
     };
-    outputs.upCommandArgs =
-      let
-        cliArgsAttr = {
-          port = "-p ${toString config.port}";
-          tui = "-t=${lib.boolToString config.tui}";
-        };
-        args =
-          lib.mapAttrsToList
-            (opt: arg: lib.optionalString (config.${opt} != null) arg)
-            cliArgsAttr;
-      in
-      mkOption {
-        type = types.str;
-        default = lib.concatStringsSep " " args;
-        internal = true;
-        readOnly = true;
-        description = ''
-          Additional CLI arguments to pass to 'process-compose up'.
-
-          Note: `-f` option is always included, pointing to generated config.
-          And is thus not handled by this option.
-        '';
-      };
   };
 }
 

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -40,10 +40,14 @@ in
       runtimeInputs = [ config.package ];
       text = ''
         ${if config.debug then "cat ${config.outputs.settingsYaml}" else ""}
-        process-compose up \
-          -f ${config.outputs.settingsYaml} \
-          ${config.outputs.upCommandArgs} \
-          "$@"
+        export PC_CONFIG_FILES=${config.outputs.settingsYaml}
+        ${
+          # Once the following issue is fixed we should be able to simply do:
+          # export PC_DISABLE_TUI=${builtins.toJSON (!config.tui)}
+          # https://github.com/F1bonacc1/process-compose/issues/75
+          if config.tui then "" else "export PC_DISABLE_TUI=true"
+        }
+        exec process-compose -p ${toString config.port} "$@"
       '';
     };
 }


### PR DESCRIPTION
improve process-compose wrapper to allow calling sub-commands other than up

tui and config file are set via env vars, which do not trigger errors for
sub-commands which do not expect corresponding command line flags

port is still set via command line argument since it is the only global one

also: make port and tui option non-nullable (see: https://github.com/Platonic-Systems/process-compose-flake/issues/34#issuecomment-1644128112)

closes #34 