### PR TITLE
Process as test

### DIFF
--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -44,10 +44,10 @@ in
                 touch $out
               '';
           in
-          (lib.filterAttrs (_: v: v != null) checks') //
-          lib.mapAttrs
+          (lib.mapAttrs
             (name: cfg: runCommandInSimulatedShell name (cfg.outputs.package true))
-            config.process-compose;
+            config.process-compose) //
+          lib.filterAttrs (_: v: v != null) checks';
       };
     });
 }

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -20,9 +20,9 @@ in
       '';
     };
     outputs.package = mkOption {
-      type = types.package;
+      type = types.functionTo types.package;
       description = ''
-        The final package that will run 'process-compose up' for this configuration.
+        Whether the final package will run 'process-compose up' for the configuration with or without test process.
       '';
     };
     debug = mkOption {
@@ -34,13 +34,13 @@ in
     };
   };
 
-  config.outputs.package =
+  config.outputs.package = enableTestProcess:
     pkgs.writeShellApplication {
       inherit name;
       runtimeInputs = [ config.package ];
       text = ''
         ${if config.debug then "cat ${config.outputs.settingsYaml}" else ""}
-        export PC_CONFIG_FILES=${config.outputs.settingsYaml}
+        export PC_CONFIG_FILES=${if enableTestProcess then config.outputs.settingsWithTestYaml else config.outputs.settingsYaml}
         ${
           # Once the following issue is fixed we should be able to simply do:
           # export PC_DISABLE_TUI=${builtins.toJSON (!config.tui)}

--- a/nix/process-compose/settings/process.nix
+++ b/nix/process-compose/settings/process.nix
@@ -48,6 +48,11 @@ in
         default = null;
         example = "on_failure";
       };
+      exit_on_end = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        example = true;
+      };
       backoff_seconds = mkOption {
         type = types.nullOr types.ints.unsigned;
         default = null;

--- a/nix/process-compose/test.nix
+++ b/nix/process-compose/test.nix
@@ -84,7 +84,7 @@ in
                   name = "process-compose-${name}";
                   text = ''
                     set -x
-                    ${lib.getExe config.outputs.package} -t=false
+                    ${lib.getExe (config.outputs.package false)} -t=false
                     echo "unexpected: process-compose exited successfully (all processes are completed?)"
                     exit 2
                   '';


### PR DESCRIPTION
Resolves #36 

TODO
- [ ] Add a PC package to `checks` only if it has a `test` process
- [ ] Mark `testScript` as deprecated and that it will be removed in the future versions