### PR TITLE
Set default port of swagger endpoint to 0

### DIFF
--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -7,7 +7,7 @@ in
   options = {
     port = mkOption {
       type = types.int;
-      default = 8080;
+      default = 0;
       description = ''
         Port to serve process-compose's Swagger API on.
       '';


### PR DESCRIPTION
resolves #41 

Will be useful here: https://github.com/juspay/services-flake/pull/38