### PR TITLE
[Bug] Test process overwrites all the other processes

### DIFF
--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -116,14 +116,13 @@ in
     {
       settingsYaml = toYAMLFile (removeNullAndEmptyAttrs config.settings);
       settingsTestYaml = toYAMLFile (removeNullAndEmptyAttrs
-        (config.settings //
+        (lib.updateManyAttrsByPath [
           {
-            processes =
-              {
-                test = { disabled = false; availability.exit_on_end = true; };
-              };
+            path = [ "processes" "test" ];
+            update = old: old // { disabled = false; availability.exit_on_end = true; };
           }
-        ));
+        ]
+          config.settings));
     };
 }
 


### PR DESCRIPTION
```nix
# Example config:
{ processess = { p1 = ...; p2 = ...; }; } // { processes = { test = ...; }; }
# Result:
{ processess = { test = ...; }; }
```