### PR TITLE
Add is_foreground option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New features
     - ~~#18: Add `testScript` option for adding flake checks based on nixosTest library.~~
     - #39: Allow `test` process to act as a test, which then gets run as part of flake checks.
+    - #52: Add `is_foreground` option
 - Fixes
     - #19: Reintroduce the `shell` option so process-compose doesn't rely on user's global bash (which doesn't exist nixosTest runners).
     - #22: `command` option is no longer wrapped in `writeShellApplication`.

--- a/nix/process-compose/settings/process.nix
+++ b/nix/process-compose/settings/process.nix
@@ -118,6 +118,11 @@ in
       default = null;
       example = true;
     };
+    is_foreground = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = true;
+    };
     disabled = mkOption {
       type = types.nullOr types.bool;
       default = if name == "test" then true else null;


### PR DESCRIPTION
The most recent release of process compose has the [option to declare a process as a foreground process](https://github.com/F1bonacc1/process-compose/commit/50b4a72d1495ee21be67e0877a297574939c8970). 