### PR TITLE
Make `process` submodule a proper submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - #19: Reintroduce the `shell` option so process-compose doesn't rely on user's global bash (which doesn't exist nixosTest runners).
     - #22: `command` option is no longer wrapped in `writeShellApplication`.
     - #20: Fix definiton of `probe.exec`
+    - #53: Make process submodule a proper submodule (allowing use of `imports` etc)
 
 
 ## 0.1.0 (Jun 12, 2023)

--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -9,7 +9,7 @@ in
         modules = [{
           options = {
             processes = mkOption {
-              type = types.attrsOf (types.submodule ./process.nix);
+              type = types.attrsOf (types.submoduleWith { modules = [ ./process.nix ]; });
               default = { };
               description = ''
                 A map of process names to their configuration.


### PR DESCRIPTION
Allowing use of `imports` etc.

culprit is `shorthandOnlyDefinesConfig` https://nixos.org/manual/nixos/stable/#sec-option-types-submodule