### PR TITLE
adds apiServer process-compose cli option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - New features
     - ~~#18: Add `testScript` option for adding flake checks based on nixosTest library.~~
     - #39: Allow `test` process to act as a test, which then gets run as part of flake checks.
-    - #52: Add `is_foreground` option
+    - New options
+      - #52: Add `is_foreground` option
+      - #54: Add `apiServer` option to control REST API server
 - Fixes
     - #19: Reintroduce the `shell` option so process-compose doesn't rely on user's global bash (which doesn't exist nixosTest runners).
     - #22: `command` option is no longer wrapped in `writeShellApplication`.

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -5,6 +5,11 @@ let
 in
 {
   options = {
+    apiServer = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable or disable process-compose's Swagger API.";
+    };
     port = mkOption {
       type = types.int;
       default = 0;

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -37,7 +37,7 @@ in
 
   config.outputs =
     let
-      mkProcessComposeWrapper = { name, tui, port, configFile }:
+      mkProcessComposeWrapper = { name, tui, apiServer, port, configFile }:
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [ config.package ];
@@ -49,6 +49,7 @@ in
               # https://github.com/F1bonacc1/process-compose/issues/75
               if tui then "" else "export PC_DISABLE_TUI=true"
             }
+            ${if apiServer then "" else "export PC_NO_SERVER=true"}
             exec process-compose -p ${toString port} "$@"
           '';
         };
@@ -58,7 +59,7 @@ in
         mkProcessComposeWrapper
           {
             inherit name;
-            inherit (config) tui port;
+            inherit (config) tui apiServer port;
             configFile = config.outputs.settingsYaml;
           };
       testPackage =
@@ -68,7 +69,7 @@ in
           mkProcessComposeWrapper
             {
               name = "${name}-test";
-              inherit (config) tui port;
+              inherit (config) tui apiServer port;
               configFile = config.outputs.settingsTestYaml;
             }
         else null;


### PR DESCRIPTION
* Process compose now supports disabling the REST API server as of [v0.80.0](https://github.com/F1bonacc1/process-compose/releases/tag/v0.80.0)
* This adds a config.apiServer option to disable the REST API if desired