### PR TITLE
Add a pre- and post- hook for the process-compose wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - New options
       - #52: Add `is_foreground` option
       - #54: Add `apiServer` option to control REST API server
+      - #56: Add `preHook` and `postHook` for running commands before and after launching process-compose respectively.
 - Fixes
     - #19: Reintroduce the `shell` option so process-compose doesn't rely on user's global bash (which doesn't exist nixosTest runners).
     - #22: `command` option is no longer wrapped in `writeShellApplication`.

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -10,12 +10,22 @@ in
       default = true;
       description = "Enable or disable process-compose's Swagger API.";
     };
+    preHook = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Shell commands to run before process-compose starts.";
+    };
     port = mkOption {
       type = types.int;
       default = 0;
       description = ''
         Port to serve process-compose's Swagger API on.
       '';
+    };
+    postHook = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Shell commands to run after process-compose completes.";
     };
     tui = mkOption {
       type = types.bool;


### PR DESCRIPTION
* Allow prep and cleanup scripts, cmds or other customizations in the wrapper with pre- and post- process-compose hooks.
* The `exec` of the process-compose call line was removed to allow for a postHook.