### PR TITLE
Add Unix Domain Socket support for Process Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
     - #55: Add `lib` flake output - library of useful functions
     - New options
       - #52: Add `is_foreground` option
-      - #54: Add `apiServer` option to control REST API server
+      - ~~#54: Add `apiServer` option to control REST API server~~
+      - $60: Add `httpServer.{enable, port, uds}` options to control the HTTP server.
       - #56: Add `preHook` and `postHook` for running commands before and after launching process-compose respectively.
 - Notable changes
     - #58: Obviate IFD by switching to JSON config

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -3,11 +3,11 @@
     "chinookDb": {
       "flake": false,
       "locked": {
-        "lastModified": 1645319735,
-        "narHash": "sha256-mrRf6ih55mHpaxiw+owvxLPVzRIbxxaj2rWEmLI5pZQ=",
+        "lastModified": 1707713355,
+        "narHash": "sha256-rF47n/uWmCYKni/ndf11gOt8yrUDiM9lTzHjG12iDtk=",
         "owner": "lerocha",
         "repo": "chinook-database",
-        "rev": "e7e6d5f008e35d3f89d8b8a4f8d38e3bfa7e34bd",
+        "rev": "4a944a942426e1f3263fe539155fb7ef92b04b4a",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685662779,
-        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692279307,
-        "narHash": "sha256-7BMWvpLpGs3zvAm0c1HVYVoVIe0m0Cfp2GPpqxDte3U=",
+        "lastModified": 1712849433,
+        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02bba6c619c91e8c8eef9ba1129d0eff31741445",
+        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1708620954,
-        "narHash": "sha256-kFgAt2kJZ9JleWgo+cFULoya31o9EiukNg1H4G0+KnM=",
+        "lastModified": 1708624100,
+        "narHash": "sha256-zZPheCD9JGg2EtK4A9BsIdyl8447egOow4fjIfHFHRg=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "dded78fff52b069bd55607b15b49739e8310efb3",
+        "rev": "44d260ddba5a51570dee54d5cd4d8984edaf98c2",
         "type": "github"
       },
       "original": {

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -16,6 +16,10 @@ in
         default = "";
         description = "Shell commands to run after process-compose completes.";
       };
+
+      # This must be grouped because, even though upstream doesn't group them in
+      # CLI opts, it does so in the source code:
+      # https://github.com/F1bonacc1/process-compose/blob/5a7b83ed8a0f6be58efa9e4940ff41517892eca2/src/cmd/root.go#L136-L144
       server = mkOption {
         description = ''
           Configuration for the process-compose server.

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -27,6 +27,9 @@ in
         type = types.submodule ({ config, ... }: {
           options = {
             enable = lib.mkEnableOption "Enable the HTTP server";
+
+            # TODO: port and uds should form an enum of submodules
+            # But we can't implement it until https://github.com/NixOS/nixpkgs/pull/254790 lands
             port = lib.mkOption {
               type = types.nullOr types.port;
               default = null;

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -6,11 +6,6 @@ in
 {
   options =
     {
-      apiServer = mkOption {
-        type = types.bool;
-        default = true;
-        description = "Enable or disable process-compose's Swagger API.";
-      };
       preHook = mkOption {
         type = types.lines;
         default = "";
@@ -27,6 +22,7 @@ in
         '';
         type = types.submodule ({ config, ... }: {
           options = {
+            enable = lib.mkEnableOption "Enable the HTTP server";
             port = lib.mkOption {
               type = types.nullOr types.port;
               default = null;
@@ -49,7 +45,7 @@ in
               type = types.str;
               internal = true;
               readOnly = true;
-              default = ''
+              default = lib.optionalString config.enable ''
                 ${if config.port != null then "--port ${builtins.toString config.port}" else ""} \
                 ${if builtins.isBool config.uds then if config.uds then "-U" else "" else "--unix-socket ${config.uds}"} \
               '';

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -4,34 +4,43 @@ let
   inherit (lib) types mkOption;
 in
 {
-  options = {
-    apiServer = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable or disable process-compose's Swagger API.";
+  options =
+    {
+      apiServer = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable or disable process-compose's Swagger API.";
+      };
+      preHook = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Shell commands to run before process-compose starts.";
+      };
+      postHook = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Shell commands to run after process-compose completes.";
+      };
+      server = mkOption {
+        type = types.submodule {
+          options = {
+            port = lib.mkOption {
+              type = types.nullOr types.port;
+              default = null;
+            };
+            uds = lib.mkOption {
+              type = types.nullOr (types.either types.bool types.str);
+              default = null;
+            };
+          };
+        };
+        default = { };
+      };
+      tui = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable or disable the TUI for the application.";
+      };
     };
-    preHook = mkOption {
-      type = types.lines;
-      default = "";
-      description = "Shell commands to run before process-compose starts.";
-    };
-    port = mkOption {
-      type = types.int;
-      default = 0;
-      description = ''
-        Port to serve process-compose's Swagger API on.
-      '';
-    };
-    postHook = mkOption {
-      type = types.lines;
-      default = "";
-      description = "Shell commands to run after process-compose completes.";
-    };
-    tui = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable or disable the TUI for the application.";
-    };
-  };
 }
 

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -20,7 +20,7 @@ in
       # This must be grouped because, even though upstream doesn't group them in
       # CLI opts, it does so in the source code:
       # https://github.com/F1bonacc1/process-compose/blob/5a7b83ed8a0f6be58efa9e4940ff41517892eca2/src/cmd/root.go#L136-L144
-      server = mkOption {
+      httpServer = mkOption {
         description = ''
           Configuration for the process-compose server.
         '';

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -22,15 +22,28 @@ in
         description = "Shell commands to run after process-compose completes.";
       };
       server = mkOption {
+        description = ''
+          Configuration for the process-compose server.
+        '';
         type = types.submodule {
           options = {
             port = lib.mkOption {
               type = types.nullOr types.port;
               default = null;
+              description = ''
+                Port to serve process-compose's Swagger API on.
+              '';
             };
             uds = lib.mkOption {
               type = types.nullOr (types.either types.bool types.str);
               default = null;
+              description = ''
+                UDP socket to serve process-compose's Swagger API on.
+
+                If set to `true`, the socket will be created in the default
+                location. If set to a string, the socket will be created at the
+                specified location.
+              '';
             };
           };
         };

--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -25,7 +25,7 @@ in
         description = ''
           Configuration for the process-compose server.
         '';
-        type = types.submodule {
+        type = types.submodule ({ config, ... }: {
           options = {
             port = lib.mkOption {
               type = types.nullOr types.port;
@@ -35,8 +35,8 @@ in
               '';
             };
             uds = lib.mkOption {
-              type = types.nullOr (types.either types.bool types.str);
-              default = null;
+              type = types.either types.bool types.str;
+              default = false;
               description = ''
                 UDP socket to serve process-compose's Swagger API on.
 
@@ -45,8 +45,17 @@ in
                 specified location.
               '';
             };
+            outputs.cliOpts = lib.mkOption {
+              type = types.str;
+              internal = true;
+              readOnly = true;
+              default = ''
+                ${if config.port != null then "--port ${builtins.toString config.port}" else ""} \
+                ${if builtins.isBool config.uds then if config.uds then "-U" else "" else "--unix-socket ${config.uds}"} \
+              '';
+            };
           };
-        };
+        });
         default = { };
       };
       tui = mkOption {

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -38,18 +38,6 @@ in
   config.outputs =
     let
       mkProcessComposeWrapper = { name, tui, apiServer, configFile, preHook, postHook, server }:
-        let
-          portSet = if server.port != null then true else false;
-          udsSet = if server.uds != false then true else false;
-          portFlag = if portSet then "-p ${toString server.port}" else "";
-          udsFlagPid = if (udsSet && (builtins.isBool server.uds)) then "-U" else "";
-          udsFlagCustom = if builtins.isString server.uds then "--unix-socket ${server.uds}" else "";
-          serverFlag =
-            if (portSet && udsSet) then
-              builtins.throw "Only one of port or uds can be set"
-            else
-              "${portFlag}${udsFlagPid}${udsFlagCustom}";
-        in
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [ config.package ];
@@ -65,7 +53,7 @@ in
 
             ${preHook}
 
-            process-compose ${serverFlag} "$@"
+            process-compose ${server.outputs.cliOpts} "$@"
 
             ${postHook}
           '';

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -51,7 +51,7 @@ in
             }
             ${preHook}
 
-            process-compose ${httpServer.outputs.cliOpts} "$@"
+            set -x; process-compose ${httpServer.outputs.cliOpts} "$@"; set +x
 
             ${postHook}
           '';

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -62,7 +62,7 @@ in
         mkProcessComposeWrapper
           {
             inherit name;
-            inherit (config) tui preHook postHook httpServer;
+            inherit (config) tui httpServer preHook postHook;
             configFile = config.outputs.settingsFile;
           };
       testPackage =
@@ -72,7 +72,7 @@ in
           mkProcessComposeWrapper
             {
               name = "${name}-test";
-              inherit (config) tui preHook postHook httpServer;
+              inherit (config) tui httpServer preHook postHook;
               configFile = config.outputs.settingsTestFile;
             }
         else null;

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -37,7 +37,7 @@ in
 
   config.outputs =
     let
-      mkProcessComposeWrapper = { name, tui, configFile, preHook, postHook, httpServer }:
+      mkProcessComposeWrapper = { name, tui, httpServer, configFile, preHook, postHook }:
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [ config.package ];

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -37,7 +37,7 @@ in
 
   config.outputs =
     let
-      mkProcessComposeWrapper = { name, tui, configFile, preHook, postHook, server }:
+      mkProcessComposeWrapper = { name, tui, configFile, preHook, postHook, httpServer }:
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [ config.package ];
@@ -51,7 +51,7 @@ in
             }
             ${preHook}
 
-            process-compose ${server.outputs.cliOpts} "$@"
+            process-compose ${httpServer.outputs.cliOpts} "$@"
 
             ${postHook}
           '';
@@ -62,7 +62,7 @@ in
         mkProcessComposeWrapper
           {
             inherit name;
-            inherit (config) tui preHook postHook server;
+            inherit (config) tui preHook postHook httpServer;
             configFile = config.outputs.settingsFile;
           };
       testPackage =
@@ -72,7 +72,7 @@ in
           mkProcessComposeWrapper
             {
               name = "${name}-test";
-              inherit (config) tui preHook postHook server;
+              inherit (config) tui preHook postHook httpServer;
               configFile = config.outputs.settingsTestFile;
             }
         else null;

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -37,7 +37,7 @@ in
 
   config.outputs =
     let
-      mkProcessComposeWrapper = { name, tui, apiServer, configFile, preHook, postHook, server }:
+      mkProcessComposeWrapper = { name, tui, configFile, preHook, postHook, server }:
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [ config.package ];
@@ -49,8 +49,6 @@ in
               # https://github.com/F1bonacc1/process-compose/issues/75
               if tui then "" else "export PC_DISABLE_TUI=true"
             }
-            ${if apiServer then "" else "export PC_NO_SERVER=true"}
-
             ${preHook}
 
             process-compose ${server.outputs.cliOpts} "$@"
@@ -64,7 +62,7 @@ in
         mkProcessComposeWrapper
           {
             inherit name;
-            inherit (config) tui apiServer preHook postHook server;
+            inherit (config) tui preHook postHook server;
             configFile = config.outputs.settingsFile;
           };
       testPackage =
@@ -74,7 +72,7 @@ in
           mkProcessComposeWrapper
             {
               name = "${name}-test";
-              inherit (config) tui apiServer preHook postHook server;
+              inherit (config) tui preHook postHook server;
               configFile = config.outputs.settingsTestFile;
             }
         else null;


### PR DESCRIPTION
Process Compose release [v1.2.0](https://github.com/F1bonacc1/process-compose/releases/tag/v1.2.0) added support for usiing UDS resolving [issue](https://github.com/F1bonacc1/process-compose/issues/172)

This is adding support for that and updating example project as well.
Relevant Process Compose documentation is [here](https://f1bonacc1.github.io/process-compose/client/#unix-domain-sockets-uds).

NOTE: flake.lock file will need one more bump after merge to be functional on process-compose-flake dependency.

