### PR TITLE
fix: allow `postHook` to run when `exit_on_end` is true

### DIFF
--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -51,7 +51,7 @@ in
             }
             ${preHook}
 
-            set -x; process-compose ${httpServer.outputs.cliOpts} "$@"; set +x
+            set -x; set +e; process-compose ${httpServer.outputs.cliOpts} "$@"; set +x; set -e
 
             ${postHook}
           '';


### PR DESCRIPTION
`exit_on_end` ends the process-compose process returning the exit code of the process that terminated.

`postHook` should run regardless of the exit code returned by `process-compose`.

Reproducer:

```sh
nix run "github:shivaraj-bh/process-compose-flake/post-hook-ex?dir=example" -- -t=false
```