### PR TITLE
docs(options): add description to options that are missing it

### DIFF
--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -5,6 +5,7 @@ in
 {
   options = {
     settings = mkOption {
+      default = { };
       type = types.submoduleWith {
         modules = [{
           options = {
@@ -22,6 +23,9 @@ in
               type = types.nullOr types.ints.unsigned;
               default = null;
               example = 3000;
+              description = ''
+                Log length to display in TUI mode.
+              '';
             };
             log_level = mkOption {
               type = types.nullOr (types.enum [
@@ -35,11 +39,17 @@ in
               ]);
               default = null;
               example = "info";
+              description = ''
+                Level of logs to output.
+              '';
             };
             log_location = mkOption {
               type = types.nullOr types.str;
               default = null;
               example = "./pc.log";
+              description = ''
+                File to write the logs to.
+              '';
             };
 
             shell = {
@@ -47,6 +57,9 @@ in
                 type = types.str;
                 default = "-c";
                 example = "-c";
+                description = ''
+                  Arguments to pass to the shell given by `shell_command`.
+                '';
               };
               shell_command = mkOption {
                 type = types.str;
@@ -57,6 +70,7 @@ in
                   `pkgs.bash`.
                 '';
                 default = lib.getExe pkgs.bash;
+                defaultText = "lib.getExe pkgs.bash";
               };
             };
 
@@ -64,6 +78,9 @@ in
               type = types.nullOr types.str;
               default = null;
               example = "0.5";
+              description = ''
+                Version of the process-compose configuration.
+              '';
             };
           };
         }];

--- a/nix/process-compose/settings/probe.nix
+++ b/nix/process-compose/settings/probe.nix
@@ -9,27 +9,45 @@ in
       type = types.ints.unsigned;
       default = 3;
       example = 3;
+      description = ''
+        Number of times to fail before giving up on restarting the process.
+      '';
     };
     http_get = mkOption {
+      description = ''
+        URL to determine the health of the process.
+      '';
       type = types.nullOr (types.submodule {
         options = {
           host = mkOption {
             type = types.str;
             example = "google.com";
+            description = ''
+              The host address which `process-compose` uses to probe the process.
+            '';
           };
           scheme = mkOption {
             type = types.str;
             default = "http";
             example = "http";
+            description = ''
+              The protocol used to probe the process listening on `host`.
+            '';
           };
           path = mkOption {
             type = types.str;
             default = "/";
             example = "/";
+            description = ''
+              The path to the healtcheck endpoint.
+            '';
           };
           port = mkOption {
             type = types.port;
             example = "8080";
+            description = ''
+              Which port to probe the process on.
+            '';
           };
         };
       });
@@ -40,29 +58,47 @@ in
         options.command = mkOption {
           type = types.str;
           example = "ps -ef | grep -v grep | grep my-proccess";
+          description = ''
+            The command to execute in order to check the health of the process.
+          '';
         };
       });
       default = null;
+      description = ''
+        Execution settings.
+      '';
     };
     initial_delay_seconds = mkOption {
       type = types.ints.unsigned;
       default = 0;
       example = 0;
+      description = ''
+        Wait for `initial_delay_seconds` before starting the probe/healthcheck.
+      '';
     };
     period_seconds = mkOption {
       type = types.ints.unsigned;
       default = 10;
       example = 10;
+      description = ''
+        Check the health every `period_seconds`. 
+      '';
     };
     success_threshold = mkOption {
       type = types.ints.unsigned;
       default = 1;
       example = 1;
+      description = ''
+        Number of successful checks before marking the process `Ready`.
+      '';
     };
     timeout_seconds = mkOption {
       type = types.ints.unsigned;
       default = 3;
       example = 3;
+      description = ''
+        How long to wait for a given probe request.
+      '';
     };
   };
 }

--- a/nix/process-compose/settings/process.nix
+++ b/nix/process-compose/settings/process.nix
@@ -31,6 +31,9 @@ in
               "process_started"
             ];
             example = "process_healthy";
+            description = ''
+              The condition the parent process must be in before starting the current one.
+            '';
           };
         };
       }));
@@ -47,21 +50,35 @@ in
         ]);
         default = null;
         example = "on_failure";
+        description = ''
+          When to restart the process.
+        '';
       };
       exit_on_end = mkOption {
         type = types.nullOr types.bool;
         default = null;
         example = true;
+        description = ''
+          Whether to gracefully stop all the processes upon the exit of the current process.
+        '';
       };
       backoff_seconds = mkOption {
         type = types.nullOr types.ints.unsigned;
         default = null;
         example = 2;
+        description = ''
+          Restart will wait `process.availability.backoff_seconds` seconds between `stop` and `start` of the process. If not configured the default value is 1s.
+        '';
       };
       max_restarts = mkOption {
         type = types.nullOr types.ints.unsigned;
         default = null;
         example = 0;
+        description = ''
+          Max. number of times to restart.
+
+          Tip: It might be sometimes useful to `exit_on_end` with `restart: on_failure` and `max_restarts` in case you want the process to recover from failure and only cause termination on success.
+        '';
       };
     };
 
@@ -70,16 +87,27 @@ in
         type = types.nullOr types.str;
         default = null;
         example = "sleep 2 && pkill -f 'test_loop.bash my-proccess'";
+        description = ''
+          The command to run while process-compose is trying to gracefully shutdown the current process.
+
+          Note: The `shutdown.command` is executed with all the Environment Variables of the primary process
+        '';
       };
       signal = mkOption {
         type = types.nullOr types.ints.unsigned;
         default = null;
         example = 15;
+        description = ''
+          If `shutdown.command` is not defined, exit the process with this signal. Defaults to `15` (SIGTERM)
+        '';
       };
       timeout_seconds = mkOption {
         type = types.nullOr types.ints.unsigned;
         default = null;
         example = 10;
+        description = ''
+          Wait for `timeout_seconds` for its completion (if not defined wait for 10 seconds). Upon timeout, `SIGKILL` is sent to the process.
+        '';
       };
     };
 
@@ -87,19 +115,31 @@ in
       type = types.nullOr types.str;
       default = null;
       example = "/tmp";
+      description = ''
+        The directory to run the process in.
+      '';
     };
     readiness_probe = mkOption {
       type = types.nullOr probeType;
       default = null;
+      description = ''
+        The settings used to check if the process is ready to accept connections.
+      '';
     };
     liveness_probe = mkOption {
       type = types.nullOr probeType;
       default = null;
+      description = ''
+        The settings used to check if the process is alive.
+      '';
     };
 
     namespace = mkOption {
       type = types.str;
       default = "default";
+      description = ''
+        Used to group processes together.
+      '';
     };
 
     environment = import ./environment.nix { inherit lib; };
@@ -107,26 +147,50 @@ in
       type = types.nullOr types.str;
       default = null;
       example = "./pc.my-proccess.log";
+      description = ''
+        Log location of the `process-compose` process.
+      '';
     };
     disable_ansi_colors = mkOption {
       type = types.nullOr types.bool;
       default = null;
       example = true;
+      description = ''
+        Whether to disable colors in the logs.
+      '';
     };
     is_daemon = mkOption {
       type = types.nullOr types.bool;
       default = null;
       example = true;
+      description = ''
+        - For processes that start services / daemons in the background, please use the `is_daemon` flag set to `true`.
+        - In case a process is daemon it will be considered running until stopped.
+        - Daemon processes can only be stopped with the `$PROCESSNAME.shutdown.command` as in the example above.
+      '';
     };
     is_foreground = mkOption {
       type = types.nullOr types.bool;
       default = null;
       example = true;
+      description = ''
+        Foreground processes are useful for cases when a full `tty` access is required (e.g. `vim`, `top`, `gdb -tui`)
+
+        - Foreground process have to be started manually (`F7`). They can be started multiple times.
+        - They are available in TUI mode only.
+        - To return to TUI, exit the foreground process.
+        - In TUI mode, a local process will be started.
+      '';
     };
     disabled = mkOption {
       type = types.nullOr types.bool;
       default = if name == "test" then true else null;
       example = true;
+      description = ''
+        Whether the process is disabled. Useful when a process is required to be started only in a given scenario, like while running in CI.
+        
+        Even if disabled, the process is still listed in the TUI and the REST client, and can be started manually when needed.
+      '';
     };
 
   };

--- a/nix/process-compose/test.nix
+++ b/nix/process-compose/test.nix
@@ -5,6 +5,11 @@ in
 {
   options = {
     outputs.check = mkOption {
+      description = ''
+        Run the `process-compose` package with `test` process Enabled.
+
+        Note: This is meant to be run in CI.
+      '';
       type = types.nullOr types.package;
       default =
         if (config.outputs.testPackage != null) then


### PR DESCRIPTION
Essential to upstream option docs to https://flake.parts/options/process-compose-flake