### PR TITLE
add makeProcessCompose funtion to use this module without flake parts…

### DIFF
--- a/example/flake.lock
+++ b/example/flake.lock
@@ -3,11 +3,11 @@
     "chinookDb": {
       "flake": false,
       "locked": {
-        "lastModified": 1707713355,
-        "narHash": "sha256-rF47n/uWmCYKni/ndf11gOt8yrUDiM9lTzHjG12iDtk=",
+        "lastModified": 1716741054,
+        "narHash": "sha256-YMma46vB72wJbIlWj0KOYUuV/e5Bqkmhylfy22XiAHs=",
         "owner": "lerocha",
         "repo": "chinook-database",
-        "rev": "4a944a942426e1f3263fe539155fb7ef92b04b4a",
+        "rev": "85eca67d22ae15b2767851cc45abc7f8764c517f",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712849433,
-        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
+        "lastModified": 1727524699,
+        "narHash": "sha256-k6YxGj08voz9NvuKExojiGXAVd69M8COtqWSKr6sQS4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
+        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
         "type": "github"
       },
       "original": {
@@ -52,29 +52,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1708624100,
-        "narHash": "sha256-zZPheCD9JGg2EtK4A9BsIdyl8447egOow4fjIfHFHRg=",
+        "lastModified": 1724606023,
+        "narHash": "sha256-rdGeNa/lCS8E1lXzPqgl+vZUUvnbEZT11Bqkx5jfYug=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "44d260ddba5a51570dee54d5cd4d8984edaf98c2",
+        "rev": "f6ce9481df9aec739e4e06b67492401a5bb4f0b1",
         "type": "github"
       },
       "original": {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -76,6 +76,27 @@
               };
             };
           };
+
+        # nix run .#ponysay up to start the process
+        # nun run .#ponysay attach to show the output
+        # nix run .#ponysay down to stop the process
+        packages.ponysay = (import ../nix/eval-modules.nix).makeProcessCompose {
+          inherit pkgs;
+          name = "ponysay";
+          modules = [{
+            arguments.detached = true;
+            settings = {
+              processes = {
+                ponysay.command = ''
+                  while true; do
+                    ${lib.getExe pkgs.ponysay} "Hi!"
+                    sleep 2
+                  done
+                '';
+              };
+            };
+          }];
+        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
     flakeModule = ./nix/flake-module.nix;
 
     lib = ./nix/lib.nix;
+    evalModules = import ./nix/eval-modules.nix;
 
     templates.default = {
       description = "Example flake using process-compose-flake";

--- a/nix/eval-modules.nix
+++ b/nix/eval-modules.nix
@@ -2,6 +2,7 @@ rec {
   evalModules = { pkgs, name, modules }: (pkgs.lib.evalModules {
     specialArgs = {
       inherit name pkgs;
+      process-compose-flake-lib = (import ./process-compose-flake-lib.nix) { lib = pkgs.lib; };
     };
     modules = [
       ./process-compose

--- a/nix/eval-modules.nix
+++ b/nix/eval-modules.nix
@@ -1,0 +1,15 @@
+rec {
+  evalModules = { pkgs, name, modules }: (pkgs.lib.evalModules {
+    specialArgs = {
+      inherit name pkgs;
+    };
+    modules = [
+      ./process-compose
+    ] ++ modules;
+  });
+
+  makeProcessCompose = { pkgs, name, modules }: (evalModules {
+    inherit pkgs name;
+    modules = modules;
+  }).config.outputs.package;
+}

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -16,7 +16,10 @@ in
           executables from process-compose configurations written as Nix attribute sets.
         '';
         type = types.attrsOf (types.submoduleWith {
-          specialArgs = { inherit pkgs; };
+          specialArgs = {
+            inherit pkgs;
+            process-compose-flake-lib = (import ./process-compose-flake-lib.nix) { inherit lib types; };
+          };
           modules = [
             ./process-compose
           ];

--- a/nix/process-compose-flake-lib.nix
+++ b/nix/process-compose-flake-lib.nix
@@ -1,0 +1,137 @@
+{ lib }:
+let
+  inherit (lib) types;
+in
+{
+  mkProcessComposeArgumentsOption = {}:
+    lib.mkOption {
+      type = types.submodule
+        ({ config, lib, ... }:
+          let inherit (lib) types mkOption;
+          in
+          {
+            options = {
+              config = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+              };
+              detached = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              disable-dotenv = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              env = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+              };
+              hide-disabled = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              keep-project = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              namespace = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+              };
+              no-deps = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              ref-rate = mkOption {
+                type = types.str;
+                default = "";
+              };
+              reverse = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              sort = mkOption {
+                type = types.str;
+                default = "";
+              };
+              theme = mkOption {
+                type = types.str;
+                default = "";
+              };
+              tui = mkOption {
+                type = types.bool;
+                default = true;
+              };
+              log-file = mkOption {
+                type = types.str;
+                default = "";
+              };
+              no-server = mkOption {
+                type = types.bool;
+                default = false;
+
+              };
+              ordered-shutdown = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              port = mkOption {
+                type = types.nullOr types.int;
+                default = null;
+              };
+              read-only = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              unix-socket = mkOption {
+                type = types.str;
+                default = "";
+              };
+              use-uds = mkOption {
+                type = types.bool;
+                default = false;
+              };
+              output = mkOption {
+                type = types.submodule {
+                  options = {
+                    global = mkOption {
+                      type = types.str;
+                      default = lib.escapeShellArgs (
+                        (lib.optionals (config.log-file != "") [ "--log-file" config.log-file ])
+                        ++ (lib.optionals config.no-server [ "--no-server" ])
+                        ++ (lib.optionals config.ordered-shutdown [ "--ordered-shutdown" ])
+                        ++ (lib.optionals (config.port != null) [ "--port" "${builtins.toString config.port}" ])
+                        ++ (lib.optionals config.read-only [ "--read-only" ])
+                        ++ (lib.optionals (config.unix-socket != "") [ "--unix-socket" config.unix-socket ])
+                        ++ (lib.optionals config.use-uds [ "--use-uds" ])
+                      );
+                    };
+                    up = mkOption {
+                      type = types.str;
+                      default = lib.escapeShellArgs (
+                        (lib.concatMap (v: [ "--config" v ]) config.config)
+                        ++ (lib.optionals config.detached [ "--detached" ])
+                        ++ (lib.optionals config.disable-dotenv [ "--disable-dotenv" ])
+                        ++ (lib.concatMap (v: [ "--env" v ]) config.env)
+                        ++ (lib.optionals config.hide-disabled [ "--hide-disabled" ])
+                        ++ (lib.optionals config.keep-project [ "--keep-project" ])
+                        ++ (lib.concatMap (v: [ "--namespace" v ]) config.namespace)
+                        ++ (lib.optionals config.no-deps [ "--no-deps" ])
+                        ++ (lib.optionals (config.ref-rate != "") [ "--ref-rate" config.ref-rate ])
+                        ++ (lib.optionals config.reverse [ "--reverse" ])
+                        ++ (lib.optionals (config.sort != "") [ "--sort" config.sort ])
+                        ++ (lib.optionals (config.theme != "") [ "--theme" config.theme ])
+                        ++ (lib.optionals config.reverse [ "--reverse" ])
+                        ++ (lib.optionals (!config.tui) [ "--tui=false" ])
+                      );
+                    };
+                  };
+                };
+                default = { };
+              };
+            };
+          });
+      default = { };
+    };
+}

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -44,7 +44,15 @@ in
           text = ''
             ${preHook}
 
-            set -x; process-compose ${arguments.global} ${arguments.up}"$@"; set +x
+            params=(${arguments.global})
+            set +u
+            if [ -z "$1" ] || [[ "$1" == "up" ]] || [[ "$1" == -* ]] ; then
+              params+=(${arguments.up})
+            fi
+
+            set -x;
+            process-compose "''${params[@]}" "$@";
+            set +x
 
             ${postHook}
           '';


### PR DESCRIPTION
I've recently asked/proposed the following two things:
- https://github.com/Platonic-Systems/process-compose-flake/discussions/74
- https://github.com/Platonic-Systems/process-compose-flake/discussions/76

After I was told that pull requests in this direction are welcome I started working on it and I'm now at a point at which I need feedback.

Even though these two features aren't directly related, I've put it in one single commit because they currently use each other. But I can also split this up if needed.

## Summary of changes & notes
- I've added the `evalModules` and `makeProcessCompose` nix functions, that can be used to use process-compose-flake without flake parts.
- I've also added an example for this in the example directory
- I've made it possible to run process-compose in detached mode. This required adding a bit more logic to the wrapper script to detect if it's running the "up" command or another command like "attach" or "down". On the latter, only a subset of arguments is passed to the process.
- I've made all of process-composes arguments configurable via specific options. I've refactored the current server options to use this interface instead. Also the path to the yaml file is now passed this way.
- Another notable thing is that arguments for the test-process can now be configured differently, defaulting to the normal arguments. This functionality is also used to pass a different yaml file for the test.


It'd be cool if you could take a look and give me some feedback.