### PR TITLE
make process-compose-flake usable without flake-parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - ~~#18: Add `testScript` option for adding flake checks based on nixosTest library.~~
     - #39: Allow `test` process to act as a test, which then gets run as part of flake checks.
     - #55: Add `lib` flake output - library of useful functions
-        - #80: Add `evalMoules`, to use process-compose-flake without flake-parts
+        - #80: Add `evalModules`, to use process-compose-flake without flake-parts
     - New options
       - #52: Add `is_foreground` option
       - ~~#54: Add `apiServer` option to control REST API server~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - ~~#18: Add `testScript` option for adding flake checks based on nixosTest library.~~
     - #39: Allow `test` process to act as a test, which then gets run as part of flake checks.
     - #55: Add `lib` flake output - library of useful functions
+        - #80: Add `evalMoules`, to use process-compose-flake without flake-parts
     - New options
       - #52: Add `is_foreground` option
       - ~~#54: Add `apiServer` option to control REST API server~~

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -3,11 +3,11 @@
     "chinookDb": {
       "flake": false,
       "locked": {
-        "lastModified": 1707713355,
-        "narHash": "sha256-rF47n/uWmCYKni/ndf11gOt8yrUDiM9lTzHjG12iDtk=",
+        "lastModified": 1716741054,
+        "narHash": "sha256-YMma46vB72wJbIlWj0KOYUuV/e5Bqkmhylfy22XiAHs=",
         "owner": "lerocha",
         "repo": "chinook-database",
-        "rev": "4a944a942426e1f3263fe539155fb7ef92b04b4a",
+        "rev": "85eca67d22ae15b2767851cc45abc7f8764c517f",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712849433,
-        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
+        "lastModified": 1727524699,
+        "narHash": "sha256-k6YxGj08voz9NvuKExojiGXAVd69M8COtqWSKr6sQS4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
+        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
         "type": "github"
       },
       "original": {
@@ -52,29 +52,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1708624100,
-        "narHash": "sha256-zZPheCD9JGg2EtK4A9BsIdyl8447egOow4fjIfHFHRg=",
+        "lastModified": 1724606023,
+        "narHash": "sha256-rdGeNa/lCS8E1lXzPqgl+vZUUvnbEZT11Bqkx5jfYug=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "44d260ddba5a51570dee54d5cd4d8984edaf98c2",
+        "rev": "f6ce9481df9aec739e4e06b67492401a5bb4f0b1",
         "type": "github"
       },
       "original": {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -78,11 +78,8 @@
           };
 
         # nix run .#ponysay up to start the process
-        packages.ponysay = inputs.process-compose-flake.lib.makeProcessCompose {
-          inherit pkgs;
-          name = "ponysay";
+        packages.ponysay = (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {
           modules = [{
-            arguments.detached = true;
             settings = {
               processes = {
                 ponysay.command = ''

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -76,6 +76,25 @@
               };
             };
           };
+
+        # nix run .#ponysay up to start the process
+        packages.ponysay = inputs.process-compose-flake.lib.makeProcessCompose {
+          inherit pkgs;
+          name = "ponysay";
+          modules = [{
+            arguments.detached = true;
+            settings = {
+              processes = {
+                ponysay.command = ''
+                  while true; do
+                    ${lib.getExe pkgs.ponysay} "Hi!"
+                    sleep 2
+                  done
+                '';
+              };
+            };
+          }];
+        };
       };
     };
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ pkgs, lib ? pkgs.lib, ... }:
 
 rec {
   # Lookup an environment in process-compose environment list
@@ -31,4 +31,23 @@ rec {
   types = {
     command = import ./process-compose/setting/command.nix { inherit lib; };
   };
+
+  # Run the process-compose-module stand-alone, without flake-parts
+  # - modules: list of modules that set process-compose-flake options
+  # - name: name of the module, you typically don't need to set this
+  # Returns the full result of the module evaluation
+  evalModules = { name ? "process-compose", modules }: (lib.evalModules {
+    specialArgs = {
+      inherit name pkgs;
+    };
+    modules = [
+      ./process-compose
+    ] ++ modules;
+  });
+
+  # Same as evalModules, but returns the process-compose process directly
+  makeProcessCompose = { name, modules }: (evalModules {
+    inherit pkgs name;
+    modules = modules;
+  }).config.outputs.package;
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -46,8 +46,8 @@ rec {
   });
 
   # Same as evalModules, but returns the process-compose process directly
-  makeProcessCompose = { name, modules }: (evalModules {
-    inherit pkgs name;
+  makeProcessCompose = { name ? "process-compose", modules }: (evalModules {
+    inherit name;
     modules = modules;
   }).config.outputs.package;
 }


### PR DESCRIPTION
See previous discussion in #79 

followup PRs are in branches [VanCoding:step2](https://github.com/VanCoding/process-compose-flake/tree/step2) and [VanCoding:step3](https://github.com/VanCoding/process-compose-flake/tree/step3)