### PR TITLE
allow "attach" and "down" subcommands to work, show it in ponysay example

### DIFF
--- a/example/flake.nix
+++ b/example/flake.nix
@@ -87,9 +87,12 @@
             };
           };
 
-        # nix run .#ponysay up to start the process
+        # nix run .#ponysay to start the process
+        # nun run .#ponysay attach to show the output
+        # nix run .#ponysay down to stop the process
         packages.ponysay = (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {
           modules = [{
+            cli.up.detached = true;
             settings = {
               processes = {
                 ponysay.command = ''

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -87,7 +87,7 @@
             };
           };
 
-        # nix run .#ponysay to start the process
+        # nix run .#ponysay up to start the process
         # nun run .#ponysay attach to show the output
         # nix run .#ponysay down to stop the process
         packages.ponysay = (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -57,7 +57,7 @@ in
             fi
 
             set -x
-            process-compose "''${params[@]}" "$@"
+            process-compose "$@" "''${params[@]}"
             set +x
 
             ${postHook}

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -45,16 +45,20 @@ in
           text = ''
             ${preHook}
 
-            run-process-compose () {
-              set -x; process-compose ${cliOutputs.global} "$@"; set +x
-            }
 
-            # Run `up` command, with arguments; unless the user wants to pass their own subcommand.
-            if [ "$#" -eq 0 ]; then
-              run-process-compose up --config ${configFile} ${cliOutputs.up}
-            else
-              run-process-compose "$@"
+            # If there are no arguments, it's the "up" command
+            # If the first argument is "up", it's also the "up" command
+            # If the first argument starts with a dash, we assume there isn't a subcommand, so it's also the "up" command
+            # Otherwise, we assume it's a subcommand other than "up"
+            params=(${cliOutputs.global})
+            set +u
+            if [ -z "$1" ] || [[ "$1" == "up" ]] || [[ "$1" == -* ]] ; then
+              params+=(--config ${configFile} ${cliOutputs.up})
             fi
+
+            set -x
+            process-compose "''${params[@]}" "$@"
+            set +x
 
             ${postHook}
           '';

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -45,14 +45,15 @@ in
           text = ''
             ${preHook}
 
-
-            # If there are no arguments, it's the "up" command
-            # If the first argument is "up", it's also the "up" command
-            # If the first argument starts with a dash, we assume there isn't a subcommand, so it's also the "up" command
-            # Otherwise, we assume it's a subcommand other than "up"
-            params=(${cliOutputs.global})
             set +u
-            if [ -z "$1" ] || [[ "$1" == "up" ]] || [[ "$1" == -* ]] ; then
+            if [ -z "$1" ] || [[ "$1" == -* ]] ; then
+              echo "process-compose-flake requires a subcommand like 'up' as the first argument. Configured subcommand cli options are ignored otherwise."
+              echo "To get a list about available subcommands, use the 'help' subcommand"
+              exit 1
+            fi
+            
+            params=(${cliOutputs.global})
+            if [[ "$1" == "up" ]] ; then
               params+=(--config ${configFile} ${cliOutputs.up})
             fi
 

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -45,15 +45,14 @@ in
           text = ''
             ${preHook}
 
-            set +u
-            if [ -z "$1" ] || [[ "$1" == -* ]] ; then
-              echo "process-compose-flake requires a subcommand like 'up' as the first argument. Configured subcommand cli options are ignored otherwise."
-              echo "To get a list about available subcommands, use the 'help' subcommand"
-              exit 1
-            fi
-            
+
+            # If there are no arguments, it's the "up" command
+            # If the first argument is "up", it's also the "up" command
+            # If the first argument starts with a dash, we assume there isn't a subcommand, so it's also the "up" command
+            # Otherwise, we assume it's a subcommand other than "up"
             params=(${cliOutputs.global})
-            if [[ "$1" == "up" ]] ; then
+            set +u
+            if [ -z "$1" ] || [[ "$1" == "up" ]] || [[ "$1" == -* ]] ; then
               params+=(--config ${configFile} ${cliOutputs.up})
             fi
 

--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -46,12 +46,12 @@ in
             ${preHook}
 
             run-process-compose () {
-              set -x; process-compose ${cliOutputs.global} --config ${configFile} "$@"; set +x
+              set -x; process-compose ${cliOutputs.global} "$@"; set +x
             }
 
             # Run `up` command, with arguments; unless the user wants to pass their own subcommand.
             if [ "$#" -eq 0 ]; then
-              run-process-compose up ${cliOutputs.up}
+              run-process-compose up --config ${configFile} ${cliOutputs.up}
             else
               run-process-compose "$@"
             fi

--- a/nix/process-compose/test.nix
+++ b/nix/process-compose/test.nix
@@ -19,7 +19,7 @@ in
             export HOME=$TMP
             cd $HOME
             # Run with tui disabled because /dev/tty is disabled in the simulated shell
-            ${lib.getExe config.outputs.testPackage} -t=false
+            ${lib.getExe config.outputs.testPackage} up -t=false
             # `runCommand` will fail if $out isn't created
             touch $out
           ''


### PR DESCRIPTION
As a follow up to my last comment here: https://github.com/Platonic-Systems/process-compose-flake/pull/81#issuecomment-2411396933

Currently it's not possible to use the "attach" and "down" (and probably all other) subcommands, because they don't allow the "--config" argument, which currently is passed all the time.

This PR is a possible fix to this, with the following drawback: explicitly setting the "up" command will not work, and it also won't work to pass any additional parameters.

I originally wanted to propose the following solution, which would be a bit better, but still not perfect:
https://github.com/VanCoding/process-compose-flake/commit/5b66d08e67f9b2521ba0ce40a4333d36257b734d

That solution would require the subcommand to be the first parameter. But that's probably something the users could live with.