### PR TITLE
test: Enable `exit_on_skipped`

### DIFF
--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -138,7 +138,13 @@ in
         (lib.updateManyAttrsByPath [
           {
             path = [ "processes" "test" ];
-            update = old: old // { disabled = false; availability.exit_on_end = true; };
+            update = old: old // {
+              disabled = false;
+              availability = {
+                exit_on_end = true;
+                exit_on_skipped = true;
+              };
+            };
           }
         ]
           config.settings));


### PR DESCRIPTION
process-compose should close if any dependency of the `test` process fails to complete/be ready.