### PR TITLE
cleanup: remove redundent xtrace shell option

### DIFF
--- a/nix/process-compose/default.nix
+++ b/nix/process-compose/default.nix
@@ -45,7 +45,6 @@ in
             ${config.cli.preHook}
 
             # IMPORTANT: We **must** use environment variables for everything but non-global options, otherwise the use of sub-command specific CLI options will prevent the user from passing their own subcommands reliably.
-            set -x
             ${config.cli.outputs.environment} PC_CONFIG_FILES=${configFile} process-compose ${config.cli.outputs.options} "$@"
 
             ${config.cli.postHook}


### PR DESCRIPTION
this commit 644a8a129f17d23df9e6cf58c9bb1097a0959ab1 removed the `set +x` but forgot to remove the `set -x`

resolves #94 