### PR TITLE
Add all known outstanding yaml config options as of process-compose v1.7.3

### DIFF
--- a/nix/process-compose/cli.nix
+++ b/nix/process-compose/cli.nix
@@ -17,13 +17,81 @@ in
       };
       environment = mkOption {
         default = { };
-        description = "Environment variables to pass to process-compose binary.";
+        description = ''
+          Environment variables to pass to process-compose binary.
+          Note that flags directly configured via cli.options will override these values.
+        '';
         type = types.submodule {
           options = {
             PC_DISABLE_TUI = mkOption {
               type = types.nullOr types.bool;
               default = null;
-              description = "Disable the TUI (Text User Interface) of process-compose";
+              description = "disable the TUI (Text User Interface) of process-compose";
+            };
+            PC_PORT_NUM = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = "port number on which to bind process-compose listener";
+            };
+            PC_CONFIG_FILES = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "comma-separated list of path to config files to load";
+            };
+            PC_SHORTCUTS_FILES = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "comma-separated list of paths to shortcut config files to load";
+            };
+            PC_NO_SERVER = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "disable HTTP server";
+            };
+            PC_SOCKET_PATH = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "path to unix socket";
+            };
+            PC_READ_ONLY = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "enable read-only mode";
+            };
+            PC_DISABLE_DOTENV = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "disable .env file loading";
+            };
+            PC_TUI_FULL_SCREEN = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "enable TUI full screen";
+            };
+            PC_HIDE_DISABLED_PROC = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "hide disabled processes";
+            };
+            PC_ORDERED_SHUTDOWN = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "shut down processes in reverse dependency order";
+            };
+            PC_RECURSIVE_METRICS = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              description = "collect metrics recursively";
+            };
+            PC_DISABLED_PROCESSES = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "comma-separated list of process to initially disable";
+            };
+            PC_LOG_FILE = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "specify the log file path";
             };
           };
         };

--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -96,10 +96,11 @@ in
 
             disable_env_expansion = mkOption {
               type = types.nullOr types.bool;
-              default = null;
+              default = true;
               example = false;
               description = ''
                 Globally disables automatic \$ variable expansion.
+                Enabled by default, unlike upstream process-compose.
               '';
             };
 

--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -51,7 +51,16 @@ in
                 File to write the logs to.
               '';
             };
-
+            log_configuration = mkOption {
+              type = types.nullOr (types.submoduleWith {
+                specialArgs = { inherit lib; };
+                modules = [ ./log-config.nix ];
+              });
+              default = null;
+              description = ''
+                The default settings for global logging.
+              '';
+            };
             shell = {
               shell_argument = mkOption {
                 type = types.str;
@@ -80,6 +89,58 @@ in
               example = "0.5";
               description = ''
                 Version of the process-compose configuration.
+              '';
+            };
+
+            vars = import ./vars.nix { inherit lib; } { };
+
+            disable_env_expansion = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              example = false;
+              description = ''
+                Globally disables automatic \$ variable expansion.
+              '';
+            };
+
+            ordered_shutdown = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              example = true;
+              description = ''
+                Causes processes to shut down in reverse dependency order.
+              '';
+            };
+
+            env_cmds = mkOption {
+              type = types.nullOr (types.attrsOf types.str);
+              default = null;
+              example = {
+                UPTIME = "uptime -p";
+                OS_NAME = "awk -F = '/PRETTY/ {print $2}' /etc/os-release";
+              };
+              description = ''
+                Dynamically populate environment variables by executing commands before starting processes.
+              '';
+            };
+
+            is_strict = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              example = true;
+              description = ''
+                Enables additional checks on YAML configuration correctness.
+              '';
+            };
+
+            extends = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              example = "process-compose.base.yaml";
+              description = ''
+                Make the current configuration inherit all values in the given file.
+
+                See https://f1bonacc1.github.io/process-compose/merge#configuration-inheritance-with-extends
               '';
             };
           };

--- a/nix/process-compose/settings/default.nix
+++ b/nix/process-compose/settings/default.nix
@@ -92,7 +92,7 @@ in
               '';
             };
 
-            vars = import ./vars.nix { inherit lib; } { };
+            vars = import ./vars.nix { inherit lib; };
 
             disable_env_expansion = mkOption {
               type = types.nullOr types.bool;

--- a/nix/process-compose/settings/log-config.nix
+++ b/nix/process-compose/settings/log-config.nix
@@ -1,0 +1,122 @@
+{ name, lib, ... }:
+
+let
+  inherit (lib) types mkOption;
+  inherit (types) nullOr listOf str enum bool;
+in
+{
+  options = {
+    rotation = mkOption {
+      type = types.submodule {
+        options = {
+          max_size_mb = mkOption {
+            type = types.nullOr types.ints.unsigned;
+            default = null;
+            example = 1;
+            description = ''
+              Maximum size in MB of the logfile before it's rolled.
+            '';
+          };
+          max_backups = mkOption {
+            type = types.nullOr types.ints.unsigned;
+            default = null;
+            example = 3;
+            description = ''
+              Maximum number of rolled logfiles to keep.
+            '';
+          };
+          max_age_days = mkOption {
+            type = types.nullOr types.ints.unsigned;
+            default = null;
+            example = 7;
+            description = ''
+              Maximum age in days to keep a rolled logfile.
+            '';
+          };
+          compress = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            example = true;
+            description = ''
+              If enabled, compress rolled logfiles with gzip.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Settings related to process log rotation.
+      '';
+    };
+
+    fields_order = mkOption {
+      type = nullOr (listOf (enum [
+        "time"
+        "level"
+        "message"
+        # technically arbitrary, but these are defined in config.
+      ])
+      );
+      default = null;
+      example = [
+        "time"
+        "level"
+        "message"
+      ];
+      description = ''
+        Order of logging fields. The default is time, level, message
+      '';
+    };
+    disable_json = mkOption {
+      type = nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        If enabled, output as plain text rather than json.
+      '';
+    };
+    timestamp_format = mkOption {
+      type = nullOr str;
+      default = null;
+      example = "2006-01-02T15:04:05.000Z";
+      description = ''
+        Timestamp format, per Go's time.Parse function.
+        Requires `add_timestamp` be enabled to be effective.
+
+        See https://pkg.go.dev/time#pkg-constants for examples.
+      '';
+    };
+    no_color = mkOption {
+      type = nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Enabling `no_color` prevents the use of ANSI colors in the logger.
+      '';
+    };
+    no_metadata = mkOption {
+      type = nullOr bool;
+      default = null;
+      example = true;
+      description = ''
+        If enabled, do not add process name and replica number to logs.
+      '';
+    };
+    add_timestamp = mkOption {
+      type = nullOr bool;
+      default = null;
+      example = true;
+      description = ''
+        If enabled, prepends a timestamp to log entries.
+      '';
+    };
+    flush_each_line = mkOption {
+      type = nullOr bool;
+      default = null;
+      example = true;
+      description = ''
+        If enabled, disables output buffering and flushes each line to the logfile immediately.
+      '';
+    };
+  };
+}

--- a/nix/process-compose/settings/probe.nix
+++ b/nix/process-compose/settings/probe.nix
@@ -49,6 +49,22 @@ in
               Which port to probe the process on.
             '';
           };
+          headers = mkOption {
+            type = types.nullOr (types.attrsOf types.str);
+            default = null;
+            example = { "x-foo" = "bar"; };
+            description = ''
+              Additional headers to set on an HTTP probe
+            '';
+          };
+          status_code = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            example = 200;
+            description = ''
+              Expected status code.
+            '';
+          };
         };
       });
       default = null;
@@ -60,6 +76,13 @@ in
           example = "ps -ef | grep -v grep | grep my-proccess";
           description = ''
             The command to execute in order to check the health of the process.
+          '';
+        };
+        options.working_dir = mkOption {
+          type = types.str;
+          example = "./directory";
+          description = ''
+            Directory in which to execute the exec probe command.
           '';
         };
       });

--- a/nix/process-compose/settings/process.nix
+++ b/nix/process-compose/settings/process.nix
@@ -119,6 +119,14 @@ in
           Wait for `timeout_seconds` for its completion (if not defined wait for 10 seconds). Upon timeout, `SIGKILL` is sent to the process.
         '';
       };
+      parent_only = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        example = false;
+        description = ''
+          If `shutdown.parent_only` is enabled, the termination signal is only sent to the parent process, not the whole group.
+        '';
+      };
     };
 
     working_dir = mkOption {
@@ -172,6 +180,18 @@ in
         Log location of the `process-compose` process.
       '';
     };
+
+    log_configuration = mkOption {
+      type = types.nullOr (types.submoduleWith {
+        specialArgs = { inherit lib; };
+        modules = [ ./log-config.nix ];
+      });
+      default = { };
+      description = ''
+        The settings for process-specific logging.
+      '';
+    };
+
     disable_ansi_colors = mkOption {
       type = types.nullOr types.bool;
       default = null;
@@ -217,10 +237,88 @@ in
       example = true;
       description = ''
         Whether the process is disabled. Useful when a process is required to be started only in a given scenario, like while running in CI.
-        
+
         Even if disabled, the process is still listed in the TUI and the REST client, and can be started manually when needed.
       '';
     };
 
+    vars = import ./vars.nix { inherit lib; } { };
+
+    replicas = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 2;
+      description = ''
+        Run multiple replicas of a given process.
+
+        Will set the PC_REPLICA_NUM var for expansion such that configs can run on unique ports or similar.
+      '';
+    };
+
+    description = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "process does a thing";
+      description = ''
+        Set a description for the process in the UI.
+      '';
+    };
+
+    entrypoint = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = [
+        "ls"
+        "-l"
+        "/some/dir"
+      ];
+      description = ''
+        Specifies the process command as a list of arguments.
+        Overridden by the command option if it is present.
+      '';
+    };
+
+    is_elevated = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = true;
+      description = ''
+        Run the command with elevated permissions,
+        using sudo or runas.
+      '';
+    };
+
+    is_disabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = false;
+      description = ''
+        Allows turning off the disabled flag when dealing with merged configs via `extend` or multiple config file command arguments.
+
+        is_disabled has priority over disabled, so in general:
+        - use disabled in base or primary configurations
+        - use is_disabled in override configurations.
+      '';
+    };
+
+    is_dotenv_disabled = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      example = true;
+      description = ''
+        If set to true, prevents process-compose from loading any .env files in the working directory.
+
+        Does not prevent other sources of env variables, such as the env section of the configuration.
+      '';
+    };
+
+    launch_timeout_seconds = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 2;
+      description = ''
+        If a parent process with is_daemon takes longer than this to fork in to the background, process-compose will stop waiting for logs and start waiting for process termination.
+      '';
+    };
   };
 }

--- a/nix/process-compose/settings/process.nix
+++ b/nix/process-compose/settings/process.nix
@@ -242,7 +242,7 @@ in
       '';
     };
 
-    vars = import ./vars.nix { inherit lib; } { };
+    vars = import ./vars.nix { inherit lib; };
 
     replicas = mkOption {
       type = types.nullOr types.int;

--- a/nix/process-compose/settings/vars.nix
+++ b/nix/process-compose/settings/vars.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+let
+  inherit (lib) types;
+  inherit (types) nullOr attrsOf anything;
+in
+args:
+lib.mkOption (
+  args
+    // {
+    # maybe YAML/JSON limited or smarter coerce to string?
+    type = nullOr (attrsOf anything);
+    description = ''
+      Variables used by process-compose to expand Go Template configs on various values.
+
+      Includes processes.process.command, working_dir, log_location, etc.
+      See https://f1bonacc1.github.io/process-compose/configuration#variables
+    '';
+    default = null;
+    example = {
+      THIS = "THAT";
+      A_NUMBER = 8888;
+      OK = "SUCCESS";
+    };
+  }
+)

--- a/nix/process-compose/settings/vars.nix
+++ b/nix/process-compose/settings/vars.nix
@@ -3,23 +3,19 @@ let
   inherit (lib) types;
   inherit (types) nullOr attrsOf anything;
 in
-args:
-lib.mkOption (
-  args
-    // {
-    # maybe YAML/JSON limited or smarter coerce to string?
-    type = nullOr (attrsOf anything);
-    description = ''
-      Variables used by process-compose to expand Go Template configs on various values.
+lib.mkOption {
+  # maybe YAML/JSON limited or smarter coerce to string?
+  type = nullOr (attrsOf anything);
+  description = ''
+    Variables used by process-compose to expand Go Template configs on various values.
 
-      Includes processes.process.command, working_dir, log_location, etc.
-      See https://f1bonacc1.github.io/process-compose/configuration#variables
-    '';
-    default = null;
-    example = {
-      THIS = "THAT";
-      A_NUMBER = 8888;
-      OK = "SUCCESS";
-    };
-  }
-)
+    Includes processes.process.command, working_dir, log_location, etc.
+    See https://f1bonacc1.github.io/process-compose/configuration#variables
+  '';
+  default = null;
+  example = {
+    THIS = "THAT";
+    A_NUMBER = 8888;
+    OK = "SUCCESS";
+  };
+}


### PR DESCRIPTION
- per-process `description` that displays in the UI
- global and per-process `log_configuration`, including `rotation`
- global and per-process `vars` for supporting Go template expansion on configs
- `env_cmds` allows running host commands to populate env variables
- `ordered_shutdown` controls the order of process shutdown
- `is_strict` does additional checking on configuration files at startup
- `disable_env_expansion` to not propagate .env variables to processes
- `http_get.{headers,status_code}` and `working_dir` for probe commands
- `replicas` to run multiple copies of processes
- `entrypoint` alternate to `command`
- `is_elevated` for sudo/runas priviledged processes
- `extends,is_disabled,is_dotenv_disabled` for multi-file fragments and overrides.
- `launch_timeout_seconds` for daemon processes