### PR TITLE
Add a default value to `.exec.working_dir`

### DIFF
--- a/nix/process-compose/settings/probe.nix
+++ b/nix/process-compose/settings/probe.nix
@@ -79,7 +79,8 @@ in
           '';
         };
         options.working_dir = mkOption {
-          type = types.str;
+          type = types.nullOr types.str;
+          default = null;
           example = "./directory";
           description = ''
             Directory in which to execute the exec probe command.


### PR DESCRIPTION
Based on the default value of `.settings.processes.<name>.working_dir`

resolves #107 

Previously failing CI in https://github.com/juspay/services-flake/pull/631, passes after using this branch